### PR TITLE
Liquid filter for translating keys by dot-notated string

### DIFF
--- a/lib/jekyll-open-sdg-plugins.rb
+++ b/lib/jekyll-open-sdg-plugins.rb
@@ -1,5 +1,6 @@
 require_relative "jekyll-open-sdg-plugins/version"
 require_relative "jekyll-open-sdg-plugins/multilingual_metadata"
+require_relative "jekyll-open-sdg-plugins/translate_key"
 
 module JekyllOpenSdgPlugins
 end

--- a/lib/jekyll-open-sdg-plugins/translate_key.rb
+++ b/lib/jekyll-open-sdg-plugins/translate_key.rb
@@ -1,0 +1,45 @@
+require "jekyll"
+
+module Jekyll
+  module TranslateKey
+    # Takes a translation key and returns a translated string according to the
+    # language of the current page. Or if none is found, returns the original
+    # key.
+    def t(key)
+      translations = @context.registers[:site].data['translations']
+      language = @context.environments.first["page"]['language']
+
+      # Keep track of the last thing we drilled to.
+      drilled = translations[language]
+
+      # Keep track of how many levels we have drilled.
+      levels_drilled = 0
+      levels = key.split('.')
+
+      # Loop through each level.
+      levels.each do |level|
+
+        # If we have drilled down to a scalar value too soon, abort.
+        break if drilled.class != Hash
+
+        if drilled.has_key? level
+          # If we find something, continue drilling.
+          drilled = drilled[level]
+          levels_drilled += 1
+        end
+
+      end
+
+      # If we didn't drill the right number of levels, return the
+      # original string.
+      if levels.length != levels_drilled
+        return key
+      end
+
+      # Otherwise we must have drilled all they way.
+      return drilled
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::TranslateKey)

--- a/lib/jekyll-open-sdg-plugins/version.rb
+++ b/lib/jekyll-open-sdg-plugins/version.rb
@@ -1,3 +1,3 @@
 module JekyllOpenSdgPlugins
-  VERSION = "0.0.1".freeze
+  VERSION = "0.0.2".freeze
 end


### PR DESCRIPTION
This adds a second way to translate inside of Liquid filters. The current way still works, which is to use the `t` global Hash variable. Example:
```
{{ t.frontpage.heading }}
```
This new second way is to pass that entire dot-notated key to a `t` Liquid filter. Example:
```
{{ "frontpage.heading" | t }}
```
The main use-case for this new method will be translating keys that exist in variables. For example, translating the country name would be done like:
```
{{ site.country.name | t }}
```
The above would allow countries to configure their `_config.yml` like so:
```
country:
  name: countries.australia
```
And as long as a translation key "countries.australia" existed, the country name would get translated according to the current page.

An important note is how it handles missing translation keys: it simply prints the original string. For example, if the `_config.yml` entry were mis-typed as:
```
country:
  name: countries.australllllia
```
Then the Liquid filter `<h2>{{ site.country.name | t }}</h2>` would output:
```
<h2>countries.australllllia</h2>
```
Because presumably the translation key "countries.australllllia" does not exist.