### PR TITLE
Look for an override field when getting the indicator name

### DIFF
--- a/lib/jekyll-open-sdg-plugins/version.rb
+++ b/lib/jekyll-open-sdg-plugins/version.rb
@@ -1,3 +1,3 @@
 module JekyllOpenSdgPlugins
-  VERSION = "0.0.10".freeze
+  VERSION = "0.0.11".freeze
 end


### PR DESCRIPTION
The previous release of this plugin is causing problems, in that it is preferring the contents of 'indicator_name' before the global metadata. This update places another field, 'indicator_name_national' in that place, and then moves 'indicator_name' *below* the global metadata. In other words, when an indicator name is to be displayed, the order of preference is:
1. indicator_name_national
2. the global name for the indicator
3. indicator_name