### PR TITLE
Support for languages_public to override language codes in URLs

### DIFF
--- a/lib/jekyll-open-sdg-plugins/create_goals.rb
+++ b/lib/jekyll-open-sdg-plugins/create_goals.rb
@@ -19,12 +19,22 @@ module JekyllOpenSdgPlugins
         if site.config['create_goals'].key?('layout')
           layout = site.config['create_goals']['layout']
         end
+        # See if we need to "map" any language codes.
+        languages_public = Hash.new
+        if site.config['languages_public']
+          languages_public = site.config['languages_public']
+        end
         # Loop through the languages.
         site.config['languages'].each_with_index do |language, index|
+          # Get the "public language" (for URLs) which may be different.
+          language_public = language
+          if languages_public[language]
+            language_public = languages_public[language]
+          end
           # Loop through the goals.
           goals.sort.each do |goal, value|
             # Add the language subfolder for all except the default (first) language.
-            dir = index == 0 ? goal.to_s : File.join(language, goal.to_s)
+            dir = index == 0 ? goal.to_s : File.join(language_public, goal.to_s)
             # Create the goal page.
             site.collections['goals'].docs << GoalPage.new(site, site.source, dir, goal, language, layout)
           end

--- a/lib/jekyll-open-sdg-plugins/create_indicators.rb
+++ b/lib/jekyll-open-sdg-plugins/create_indicators.rb
@@ -13,12 +13,22 @@ module JekyllOpenSdgPlugins
         if site.config['create_indicators'].key?('layout')
           layout = site.config['create_indicators']['layout']
         end
+        # See if we need to "map" any language codes.
+        languages_public = Hash.new
+        if site.config['languages_public']
+          languages_public = site.config['languages_public']
+        end
         # Loop through the languages.
         site.config['languages'].each_with_index do |language, index|
+          # Get the "public language" (for URLs) which may be different.
+          language_public = language
+          if languages_public[language]
+            language_public = languages_public[language]
+          end
           # Loop through the indicators (using metadata as a list).
           site.data['meta'].each do |inid, meta|
             # Add the language subfolder for all except the default (first) language.
-            dir = index == 0 ? inid : File.join(language, inid)
+            dir = index == 0 ? inid : File.join(language_public, inid)
             # Create the indicator page.
             site.collections['indicators'].docs << IndicatorPage.new(site, site.source, dir, inid, language, layout)
           end

--- a/lib/jekyll-open-sdg-plugins/create_pages.rb
+++ b/lib/jekyll-open-sdg-plugins/create_pages.rb
@@ -54,12 +54,23 @@ module JekyllOpenSdgPlugins
           pages = site.config['create_pages']['pages']
         end
 
+        # See if we need to "map" any language codes.
+        languages_public = Hash.new
+        if site.config['languages_public']
+          languages_public = site.config['languages_public']
+        end
+
         # Loop through the languages.
         site.config['languages'].each_with_index do |language, index|
+          # Get the "public language" (for URLs) which may be different.
+          language_public = language
+          if languages_public[language]
+            language_public = languages_public[language]
+          end
           # Loop through the pages.
           pages.each do |page|
             # Add the language subfolder for all except the default (first) language.
-            dir = index == 0 ? page['folder'] : File.join(language, page['folder'])
+            dir = index == 0 ? page['folder'] : File.join(language_public, page['folder'])
             # Create the page.
             site.pages << OpenSdgPage.new(site, site.source, dir, page, language)
           end

--- a/lib/jekyll-open-sdg-plugins/version.rb
+++ b/lib/jekyll-open-sdg-plugins/version.rb
@@ -1,3 +1,3 @@
 module JekyllOpenSdgPlugins
-  VERSION = "0.0.14".freeze
+  VERSION = "0.0.15".freeze
 end


### PR DESCRIPTION
This is needed to allow for [this feature](https://github.com/open-sdg/open-sdg/issues/349).

It should have no effect is the `languages_public` site config is not present.

A corresponding PR for open-sdg will be posted next.