### PR TITLE
Support metadata subfolder translation in untranslated builds

### DIFF
--- a/lib/jekyll-open-sdg-plugins/sdg_variables.rb
+++ b/lib/jekyll-open-sdg-plugins/sdg_variables.rb
@@ -228,6 +228,13 @@ module JekyllOpenSdgPlugins
             meta = site.data[language]['meta'][meta_key]
           else
             meta = site.data['meta'][meta_key]
+            # Also for untranslated builds, we need to support the "subfolder"
+            # approach for metadata translation. (This is handled at build-time
+            # for translated builds.)
+            if meta.has_key? language
+              meta = meta.merge(meta[language])
+              meta.delete(language)
+            end
           end
 
           # Set the goal for this language, once only.

--- a/lib/jekyll-open-sdg-plugins/version.rb
+++ b/lib/jekyll-open-sdg-plugins/version.rb
@@ -1,3 +1,3 @@
 module JekyllOpenSdgPlugins
-  VERSION = "1.0.0.rc22".freeze
+  VERSION = "1.0.0.rc23".freeze
 end


### PR DESCRIPTION
This restored support of subfolder translation, for untranslated builds. For translated builds, this has already happened.