### PR TITLE
Standalone indicators

### DIFF
--- a/lib/jekyll-open-sdg-plugins/create_goals.rb
+++ b/lib/jekyll-open-sdg-plugins/create_goals.rb
@@ -23,6 +23,9 @@ module JekyllOpenSdgPlugins
           metadata = site.data['meta']
         end
         metadata.each do |inid, indicator|
+          if indicator.has_key?('standalone') and indicator['standalone']
+            next
+          end
           goal = inid.split('-')[0].to_i
           goals[goal] = true
         end

--- a/lib/jekyll-open-sdg-plugins/create_indicators.rb
+++ b/lib/jekyll-open-sdg-plugins/create_indicators.rb
@@ -34,6 +34,9 @@ module JekyllOpenSdgPlugins
           end
           # Loop through the indicators (using metadata as a list).
           metadata.each do |inid, meta|
+            if meta.has_key?('standalone') and meta['standalone']
+              next
+            end
             # Add the language subfolder for all except the default (first) language.
             dir = index == 0 ? inid : File.join(language_public, inid)
             # Create the indicator page.

--- a/lib/jekyll-open-sdg-plugins/create_indicators.rb
+++ b/lib/jekyll-open-sdg-plugins/create_indicators.rb
@@ -34,11 +34,13 @@ module JekyllOpenSdgPlugins
           end
           # Loop through the indicators (using metadata as a list).
           metadata.each do |inid, meta|
-            if meta.has_key?('standalone') and meta['standalone']
-              next
+            permalink = inid
+            if meta.has_key?('permalink') and meta['permalink'] != ''
+              permalink = meta['permalink']
             end
             # Add the language subfolder for all except the default (first) language.
-            dir = index == 0 ? inid : File.join(language_public, inid)
+            dir = index == 0 ? permalink : File.join(language_public, permalink)
+
             # Create the indicator page.
             site.collections['indicators'].docs << IndicatorPage.new(site, site.source, dir, inid, language, layout)
           end
@@ -67,9 +69,13 @@ module JekyllOpenSdgPlugins
                 language_public = languages_public[language]
               end
               metadata.each do |inid, meta|
-                dir = File.join('config', inid)
+                permalink = inid
+                if meta.has_key?('permalink') and meta['permalink'] != ''
+                  permalink = meta['permalink']
+                end
+                dir = File.join('config', permalink)
                 if index != 0
-                  dir = File.join(language_public, 'config', inid)
+                  dir = File.join(language_public, 'config', permalink)
                 end
                 site.collections['pages'].docs << IndicatorConfigPage.new(site, site.source, dir, inid, language, meta, layout)
               end


### PR DESCRIPTION
Allow indicators to have a metadata field of `standalone` which prevents them from affecting the goal pages that are automatically created. Also support a `permalink` metadata field which can be used to control the permalink of the automatically created indicator pages.