### PR TITLE
Make the meta/data edit links optional

### DIFF
--- a/lib/jekyll-open-sdg-plugins/schema-site-config.json
+++ b/lib/jekyll-open-sdg-plugins/schema-site-config.json
@@ -308,7 +308,6 @@
         },
         "data_edit_url": {
             "type": "string",
-            "minLength": 1,
             "title": "Data edit URL",
             "description": "This setting controls the URL of the 'Edit Data' buttons that appear on the staging site's indicator pages.",
             "links": [
@@ -931,7 +930,6 @@
         },
         "metadata_edit_url": {
             "type": "string",
-            "minLength": 1,
             "title": "Metadata edit URL",
             "description": "This setting controls the URL of the 'Edit Metadata' buttons that appear on the staging site's indicator pages.",
             "links": [


### PR DESCRIPTION
I don't remember the reasons for making these fields required, but with more and more implementations of Open SDG using data sources that are not file-based, it seems like these fields should be optional.