### PR TITLE
Set a variable for the untranslated data prefix

### DIFF
--- a/lib/jekyll-open-sdg-plugins/sdg_variables.rb
+++ b/lib/jekyll-open-sdg-plugins/sdg_variables.rb
@@ -388,6 +388,9 @@ module JekyllOpenSdgPlugins
           end
           if opensdg_translated_builds(site)
             doc.data['remote_data_prefix'] = File.join(doc.data['remote_data_prefix'], language)
+            doc.data['remote_data_prefix_untranslated'] = File.join(doc.data['remote_data_prefix'], 'untranslated')
+          else
+            doc.data['remote_data_prefix_untranslated'] = doc.data['remote_data_prefix']
           end
 
           # Set the logo for this page.


### PR DESCRIPTION
This sets an untranslated version of remote_data_prefix for use in the platform.