### PR TITLE
Config setting for indicator_available

### DIFF
--- a/lib/jekyll-open-sdg-plugins/schema-indicator-config.json
+++ b/lib/jekyll-open-sdg-plugins/schema-indicator-config.json
@@ -443,6 +443,17 @@
                 }
             ]
         },
+        "indicator_available": {
+            "type": "string",
+            "title": "Indicator available",
+            "description": "An optional sub-title for the indicator, which displays below the indicator name. Intended for cases where the available data is slightly different than the indicator name.",
+            "links": [
+                {
+                    "rel": "More information on the indicator available setting",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/metadata-format/#recommended-special-fields"
+                }
+            ]
+        },
         "indicator_name": {
             "type": "string",
             "title": "Indicator name",


### PR DESCRIPTION
The indicator_available setting has special functionality in Open SDG so it should be indicator configuration instead of metadata.