### PR TITLE
Site config settings for repo urls and special treatment in config forms

### DIFF
--- a/lib/jekyll-open-sdg-plugins/create_indicators.rb
+++ b/lib/jekyll-open-sdg-plugins/create_indicators.rb
@@ -13,6 +13,34 @@ module JekyllOpenSdgPlugins
       form_settings_config = site.config['indicator_config_form']
       form_settings_meta = site.config['indicator_metadata_form']
       form_settings_data = site.config['indicator_data_form']
+
+      # Special treatment of repository_link settings: prefix them
+      # with the repository_url_data site config if needed.
+      repo_url = site.config['repository_url_data']
+      if repo_url && repo_url != '' && repo_url.start_with?('http')
+        if form_settings_config != nil && form_settings_config && form_settings_config['enabled']
+          if form_settings_config['repository_link'] && form_settings_config['repository_link'] != ''
+            unless form_settings_config['repository_link'].start_with?('http')
+              form_settings_config['repository_link'] = repo_url + form_settings_config['repository_link']
+            end
+          end
+        end
+        if form_settings_meta != nil && form_settings_meta && form_settings_meta['enabled']
+          if form_settings_meta['repository_link'] && form_settings_meta['repository_link'] != ''
+            unless form_settings_meta['repository_link'].start_with?('http')
+              form_settings_meta['repository_link'] = repo_url + form_settings_meta['repository_link']
+            end
+          end
+        end
+        if form_settings_data != nil && form_settings_data && form_settings_data['enabled']
+          if form_settings_data['repository_link'] && form_settings_data['repository_link'] != ''
+            unless form_settings_data['repository_link'].start_with?('http')
+              form_settings_data['repository_link'] = repo_url + form_settings_data['repository_link']
+            end
+          end
+        end
+      end
+
       translations = site.data['translations']
       # If site.create_indicators is set, create indicators per the metadata.
       if (language_config and indicator_config and indicator_config.key?('layout') and indicator_config['layout'] != '')

--- a/lib/jekyll-open-sdg-plugins/create_pages.rb
+++ b/lib/jekyll-open-sdg-plugins/create_pages.rb
@@ -65,9 +65,9 @@ module JekyllOpenSdgPlugins
         pages = pages.clone
 
         # Hardcode the site configuration page if it's not already there.
+        form_settings = site.config['site_config_form']
         config_page = pages.find { |page| page['layout'] == 'config-builder' }
         if config_page == nil
-          form_settings = site.config['site_config_form']
           if form_settings && form_settings['enabled']
             pages.push({
               'folder' => '/config',
@@ -75,9 +75,22 @@ module JekyllOpenSdgPlugins
               'title' => 'Open SDG site configuration',
               'config_type' => 'site',
               'config_filename' => 'site_config.yml',
-              'form_settings' => form_settings,
             })
           end
+        end
+        # Make sure the form settings are set.
+        config_page = pages.find { |page| page['layout'] == 'config-builder' }
+        if config_page != nil && form_settings && form_settings['enabled']
+          # Special treatment of repository_link.
+          if form_settings['repository_link'] && form_settings['repository_link'] != ''
+            unless form_settings['repository_link'].start_with?('http')
+              repo_url = site.config['repository_url_site']
+              if repo_url && repo_url != '' && repo_url.start_with?('http')
+                form_settings['repository_link'] = repo_url + form_settings['repository_link']
+              end
+            end
+          end
+          config_page['form_settings'] = form_settings
         end
 
         # See if we need to "map" any language codes.

--- a/lib/jekyll-open-sdg-plugins/schema-site-config.json
+++ b/lib/jekyll-open-sdg-plugins/schema-site-config.json
@@ -1189,6 +1189,28 @@
                 }
             ]
         },
+        "repository_url_data": {
+            "type": "string",
+            "title": "Repository URL - Data",
+            "description": "The URL of your data repository, eg: https://github.com/my-github-org/data",
+            "links": [
+                {
+                    "rel": "More information on the data repository URL setting",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#repository_url_data"
+                }
+            ]
+        },
+        "repository_url_site": {
+            "type": "string",
+            "title": "Repository URL - Site",
+            "description": "The URL of your site repository, eg: https://github.com/my-github-org/site",
+            "links": [
+                {
+                    "rel": "More information on the site repository URL setting",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#repository_url_site"
+                }
+            ]
+        },
         "search_index_boost": {
             "options": {"collapsed": true},
             "type": "array",

--- a/lib/jekyll-open-sdg-plugins/sdg_variables.rb
+++ b/lib/jekyll-open-sdg-plugins/sdg_variables.rb
@@ -68,7 +68,7 @@ module JekyllOpenSdgPlugins
     # The Jekyll baseurl is user-configured, and can be inconsistent. This
     # ensure it is consistent in whether it starts/ends with a slash.
     def normalize_baseurl(baseurl)
-      if baseurl == ''
+      if baseurl == '' || baseurl.nil?
         baseurl = '/'
       end
       if !baseurl.start_with? '/'

--- a/lib/jekyll-open-sdg-plugins/site_configuration.rb
+++ b/lib/jekyll-open-sdg-plugins/site_configuration.rb
@@ -37,7 +37,7 @@ module JekyllOpenSdgPlugins
       ]
       env_settings.each do |setting|
           if ENV.has_key?(setting)
-            site.data[setting.downcase] = ENV[setting]
+            site.config[setting.downcase] = ENV[setting]
           end
       end
     end

--- a/lib/jekyll-open-sdg-plugins/site_configuration.rb
+++ b/lib/jekyll-open-sdg-plugins/site_configuration.rb
@@ -31,6 +31,15 @@ module JekyllOpenSdgPlugins
         hash_to_hash(site.data['site_config_prod'], site.config)
       end
 
+      # Look for environment variables for some settings.
+      env_settings = [
+        'REPOSITORY_URL_SITE',
+      ]
+      env_settings.each do |setting|
+          if ENV.has_key?(setting)
+            site.data[setting.downcase] = ENV[setting]
+          end
+      end
     end
 
     # Copy properties from a hash onto another hash.


### PR DESCRIPTION
This adds config items for "repository_url_data" and "repository_url_site". This are intended to hold simple links directly to the repositories. This PR also uses the value of those settings as a prefix for the "repository_link" settings in the various config form settings. More details will be in a documentation PR on open-sdg.