### PR TITLE
Reporting status config setting

### DIFF
--- a/lib/jekyll-open-sdg-plugins.rb
+++ b/lib/jekyll-open-sdg-plugins.rb
@@ -12,6 +12,7 @@ require_relative "jekyll-open-sdg-plugins/sdg_variables"
 require_relative "jekyll-open-sdg-plugins/search_index"
 require_relative "jekyll-open-sdg-plugins/validate_indicator_config"
 require_relative "jekyll-open-sdg-plugins/metadata_schema_to_config"
+require_relative "jekyll-open-sdg-plugins/backwards_compatibility"
 
 module JekyllOpenSdgPlugins
 end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -14,7 +14,8 @@ module JekyllOpenSdgPlugins
         unless site.config.has_key?('reporting_status') &&
                site.config['reporting_status'].has_key?('status_types') &&
                site.config['reporting_status']['status_types'].count > 0
-            puts "Foo"
+            legacy_reporting_status_types = site.data['schema']
+            puts legacy_reporting_status_types
         end
     end
   end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -22,6 +22,7 @@ module JekyllOpenSdgPlugins
                 'label': status_type['translation_key'],
               }
             end
+            puts site.config['reporting_status']
         end
         # Also fill in the "reporting" data with things needed by older templates.
         puts site.data['reporting']

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -30,8 +30,8 @@ module JekyllOpenSdgPlugins
         reporting_status_types = reporting_status['field']['options']
         site.config['reporting_status']['status_types'] = reporting_status_types.map do |status_type|
           {
-            'value': status_type['value'],
-            'label': status_type['translation_key'],
+            'value' => status_type['value'],
+            'label' => status_type['translation_key'],
           }
         end
       end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -18,7 +18,7 @@ module JekyllOpenSdgPlugins
             reporting_status = site.data['schema'].detect {|f| f['name'] == 'reporting_status' }
             reporting_status_types = reporting_status['field']['options']
             site.config['reporting_status']['status_types'] = reporting_status_types.map do |status_type|
-              return {
+              {
                 'value': status_type['value'],
                 'label': status_type['translation_key'],
               }

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -35,6 +35,7 @@ module JekyllOpenSdgPlugins
 
       # Also fill in the "reporting" data with things needed by older templates.
       add_translation_keys(site.data['reporting']['statuses'], site)
+      foo = bar['fdsfds'].sdkfjdsf
       add_translation_keys(site.data['reporting']['overall']['statuses'], site)
 
       if site.data['reporting'].has_key?('extra_fields')

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -10,7 +10,8 @@ module JekyllOpenSdgPlugins
       statuses.each do |status|
         status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
         if status_in_site_config.nil?
-          opensdg_notice('Unexpected reporting status type: ' + status['status'])
+          opensdg_notice('Unexpected reporting status type: ' + status['status'] + '. Expected reporting status types:'
+          puts site.config['reporting_status']['status_types']
         end
         status['translation_key'] = status_in_site_config['label']
       end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -10,25 +10,43 @@ module JekyllOpenSdgPlugins
     # as the Open SDG API changes over time.
     def generate(site)
 
-        # Handle legacy treatment of reporting status types.
-        puts 'here'
-        unless site.config.has_key?('reporting_status') &&
-               site.config['reporting_status'].has_key?('status_types') &&
-               site.config['reporting_status']['status_types'].count > 0
-            reporting_status = site.data['schema'].detect {|f| f['name'] == 'reporting_status' }
-            reporting_status_types = reporting_status['field']['options']
-            site.config['reporting_status']['status_types'] = reporting_status_types.map do |status_type|
-              {
-                'value': status_type['value'],
-                'label': status_type['translation_key'],
-              }
-            end
-            puts site.config['reporting_status']
-            puts 'still here'
+      # Handle legacy treatment of reporting status types.
+      unless site.config.has_key?('reporting_status') &&
+             site.config['reporting_status'].has_key?('status_types') &&
+             site.config['reporting_status']['status_types'].count > 0
+        reporting_status = site.data['schema'].detect {|f| f['name'] == 'reporting_status' }
+        reporting_status_types = reporting_status['field']['options']
+        site.config['reporting_status']['status_types'] = reporting_status_types.map do |status_type|
+          {
+            'value': status_type['value'],
+             'label': status_type['translation_key'],
+          }
         end
-        # Also fill in the "reporting" data with things needed by older templates.
-        puts site.data['reporting']
-        puts 'again'
+      end
+      # Also fill in the "reporting" data with things needed by older templates.
+      def add_translation_keys(statuses)
+        statuses.each do |status|
+          status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
+          status['translation_key'] = status_in_site_config['label']
+        end
+      end
+
+      add_translation_keys(site.data['reporting']['statuses'])
+      add_translation_keys(site.data['reporting']['overall']['statuses']
+      if site.data['reporting'].has_key?('extra_fields')
+        site.data['reporting']['extra_fields'] each do |key, extra_field|
+          extra_field.each do |extra_field_value|
+            add_translation_keys(extra_field_value['statuses'])
+          end
+        end
+      end
+      if site.data['reporting'].has_key?('goals')
+        site.data['reporting']['goals'] each do |key, goal|
+          goal.each do |goal_value|
+            add_translation_keys(goal_value['statuses'])
+          end
+        end
+      end
     end
   end
 end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -23,6 +23,8 @@ module JekyllOpenSdgPlugins
               }
             end
         end
+        # Also fill in the "reporting" data with things needed by older templates.
+        puts site.data['reporting']
     end
   end
 end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -7,6 +7,8 @@ module JekyllOpenSdgPlugins
     priority :low
 
     def add_translation_keys(statuses, site)
+      puts statuses
+      puts site.config['reporting_status']
       statuses.each do |status|
         status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
         status['translation_key'] = status_in_site_config['label']

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -10,8 +10,8 @@ module JekyllOpenSdgPlugins
       statuses.each do |status|
         status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
         if status_in_site_config.nil?
-          opensdg_notice('Unexpected reporting status type: ' + status['status'] + '. Expected reporting status types:'
-          puts (site.config['reporting_status']['status_types'].map { |status_type| status_type.value } )
+          opensdg_notice('Unexpected reporting status type: ' + status['status'] + '. Expected reporting status types:')
+          puts site.config['reporting_status']['status_types'].map { |status_type| status_type.value }
         end
         status['translation_key'] = status_in_site_config['label']
       end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -57,7 +57,7 @@ module JekyllOpenSdgPlugins
         end
       end
 
-      puts type(site.config['reporting_status']['status_types'])
+      puts site.config['reporting_status']['status_types'].class
     end
   end
 end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -57,7 +57,7 @@ module JekyllOpenSdgPlugins
         end
       end
 
-      puts site.config['reporting_types']['status_types']
+      puts site
     end
   end
 end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -57,7 +57,7 @@ module JekyllOpenSdgPlugins
         end
       end
 
-      puts site.config['reporting_status']['status_types']
+      puts type(site.config['reporting_status']['status_types'])
     end
   end
 end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -44,10 +44,7 @@ module JekyllOpenSdgPlugins
       add_translation_keys(site.data['reporting']['overall']['statuses'], site)
 
       if site.data['reporting'].has_key?('extra_fields')
-        puts 'extra fields'
         site.data['reporting']['extra_fields'].each do |key, extra_field|
-          puts key
-          puts extra_field
           extra_field.each do |extra_field_value|
             add_translation_keys(extra_field_value['statuses'], site)
           end
@@ -55,10 +52,7 @@ module JekyllOpenSdgPlugins
       end
 
       if site.data['reporting'].has_key?('goals')
-        puts 'goals'
-        site.data['reporting']['goals'].each do |key, goal|
-          puts key
-          puts goal
+        site.data['reporting']['goals'].each do |goal|
           goal.each do |goal_value|
             add_translation_keys(goal_value['statuses'], site)
           end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -56,8 +56,6 @@ module JekyllOpenSdgPlugins
           add_translation_keys(goal['statuses'], site)
         end
       end
-
-      puts site.config['reporting_status']['status_types'].class
     end
   end
 end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -53,9 +53,7 @@ module JekyllOpenSdgPlugins
 
       if site.data['reporting'].has_key?('goals')
         site.data['reporting']['goals'].each do |goal|
-          goal.each do |goal_value|
-            add_translation_keys(goal_value['statuses'], site)
-          end
+          add_translation_keys(goal['statuses'], site)
         end
       end
     end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -15,8 +15,7 @@ module JekyllOpenSdgPlugins
                site.config['reporting_status'].has_key?('status_types') &&
                site.config['reporting_status']['status_types'].count > 0
             puts "Foo"
-        endunless
-
+        end
     end
   end
 end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -8,9 +8,9 @@ module JekyllOpenSdgPlugins
 
     def add_translation_keys(statuses, site)
       statuses.each do |status|
+        puts status
         status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
         if status_in_site_config.nil?
-          puts site.config['reporting_status']['status_types']
           opensdg_notice('Unexpected reporting status type: ' + status['status'] + '. Expected reporting status types:')
           puts site.config['reporting_status']['status_types'].map { |s| s['value'] }
         end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -13,7 +13,7 @@ module JekyllOpenSdgPlugins
         unless status.has_key?(status_var)
           status_var = 'status'
         end
-        status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status[status_var]] }
+        status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status[status_var] }
         if status_in_site_config.nil?
           opensdg_notice('Unexpected reporting status type: ' + status[status_var] + '. Expected reporting status types:')
           puts site.config['reporting_status']['status_types'].map { |s| s['value'] }

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -7,10 +7,11 @@ module JekyllOpenSdgPlugins
     priority :low
 
     def add_translation_keys(statuses, site)
-      puts statuses
-      puts site.config['reporting_status']
       statuses.each do |status|
         status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
+        if status_in_site_config == Nil
+          opensdg_notice('Unexpected reporting status type: ' + status['status'])
+        end
         status['translation_key'] = status_in_site_config['label']
       end
     end
@@ -35,12 +36,9 @@ module JekyllOpenSdgPlugins
 
       # Also fill in the "reporting" data with things needed by older templates.
       add_translation_keys(site.data['reporting']['statuses'], site)
-      foo = bar['fdsfds'].sdkfjdsf
       add_translation_keys(site.data['reporting']['overall']['statuses'], site)
 
       if site.data['reporting'].has_key?('extra_fields')
-        puts 'about to loop'
-        puts site.data['reporting']['extra_fields']
         site.data['reporting']['extra_fields'].each do |key, extra_field|
           extra_field.each do |extra_field_value|
             add_translation_keys(extra_field_value['statuses'], site)

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -9,9 +9,9 @@ module JekyllOpenSdgPlugins
     def add_translation_keys(statuses, site)
       statuses.each do |status|
         puts status
-        status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
+        status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['value'] }
         if status_in_site_config.nil?
-          opensdg_notice('Unexpected reporting status type: ' + status['status'] + '. Expected reporting status types:')
+          opensdg_notice('Unexpected reporting status type: ' + status['value'] + '. Expected reporting status types:')
           puts site.config['reporting_status']['status_types'].map { |s| s['value'] }
         end
         status['translation_key'] = status_in_site_config['label']

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -57,7 +57,7 @@ module JekyllOpenSdgPlugins
         end
       end
 
-      puts site
+      puts site.config['reporting_status']['status_types']
     end
   end
 end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -1,0 +1,22 @@
+require "jekyll"
+require_relative "helpers"
+
+module JekyllOpenSdgPlugins
+  class BackwardsCompatibility < Jekyll::Generator
+    safe true
+    priority :low
+
+    # This file is used to avoid any backwards compatibility issues
+    # as the Open SDG API changes over time.
+    def generate(site)
+
+        # Handle legacy treatment of reporting status types.
+        unless site.config.has_key?('reporting_status') &&
+               site.config['reporting_status'].has_key?('status_types') &&
+               site.config['reporting_status']['status_types'].count > 0
+            puts "Foo"
+        endunless
+
+    end
+  end
+end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -11,7 +11,7 @@ module JekyllOpenSdgPlugins
         status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
         if status_in_site_config.nil?
           opensdg_notice('Unexpected reporting status type: ' + status['status'] + '. Expected reporting status types:')
-          puts site.config['reporting_status']['status_types'].map { |status_type| status_type.value }
+          puts site.config['reporting_status']['status_types'].map { |status_type| status_type['value'] }
         end
         status['translation_key'] = status_in_site_config['label']
       end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -56,6 +56,8 @@ module JekyllOpenSdgPlugins
           add_translation_keys(goal['statuses'], site)
         end
       end
+
+      puts site.config['reporting_types']['status_types']
     end
   end
 end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -8,7 +8,6 @@ module JekyllOpenSdgPlugins
 
     def add_translation_keys(statuses, site)
       statuses.each do |status|
-        puts status
         status_var = 'value'
         unless status.has_key?(status_var)
           status_var = 'status'
@@ -45,7 +44,10 @@ module JekyllOpenSdgPlugins
       add_translation_keys(site.data['reporting']['overall']['statuses'], site)
 
       if site.data['reporting'].has_key?('extra_fields')
+        puts 'extra fields'
         site.data['reporting']['extra_fields'].each do |key, extra_field|
+          puts key
+          puts extra_field
           extra_field.each do |extra_field_value|
             add_translation_keys(extra_field_value['statuses'], site)
           end
@@ -53,7 +55,10 @@ module JekyllOpenSdgPlugins
       end
 
       if site.data['reporting'].has_key?('goals')
+        puts 'goals'
         site.data['reporting']['goals'].each do |key, goal|
+          puts key
+          puts goal
           goal.each do |goal_value|
             add_translation_keys(goal_value['statuses'], site)
           end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -11,6 +11,7 @@ module JekyllOpenSdgPlugins
     def generate(site)
 
         # Handle legacy treatment of reporting status types.
+        puts 'here'
         unless site.config.has_key?('reporting_status') &&
                site.config['reporting_status'].has_key?('status_types') &&
                site.config['reporting_status']['status_types'].count > 0
@@ -23,9 +24,11 @@ module JekyllOpenSdgPlugins
               }
             end
             puts site.config['reporting_status']
+            puts 'still here'
         end
         # Also fill in the "reporting" data with things needed by older templates.
         puts site.data['reporting']
+        puts 'again'
     end
   end
 end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -9,7 +9,7 @@ module JekyllOpenSdgPlugins
     def add_translation_keys(statuses, site)
       statuses.each do |status|
         status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
-        if status_in_site_config == Nil
+        if status_in_site_config.nil?
           opensdg_notice('Unexpected reporting status type: ' + status['status'])
         end
         status['translation_key'] = status_in_site_config['label']

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -6,12 +6,18 @@ module JekyllOpenSdgPlugins
     safe true
     priority :low
 
+    def add_translation_keys(statuses, site)
+      statuses.each do |status|
+        status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
+        status['translation_key'] = status_in_site_config['label']
+      end
+    end
+
     # This file is used to avoid any backwards compatibility issues
     # as the Open SDG API changes over time.
     def generate(site)
 
       # Handle legacy treatment of reporting status types.
-      puts 'foo'
       unless (site.config.has_key?('reporting_status') &&
              site.config['reporting_status'].has_key?('status_types') &&
              site.config['reporting_status']['status_types'].count > 0)
@@ -24,29 +30,23 @@ module JekyllOpenSdgPlugins
           }
         end
       end
-      puts 'foo2'
-      # Also fill in the "reporting" data with things needed by older templates.
-      def add_translation_keys(statuses)
-        statuses.each do |status|
-          status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
-          status['translation_key'] = status_in_site_config['label']
-        end
-      end
 
-      add_translation_keys(site.data['reporting']['statuses'])
-      add_translation_keys(site.data['reporting']['overall']['statuses'])
+      # Also fill in the "reporting" data with things needed by older templates.
+      add_translation_keys(site.data['reporting']['statuses'], site)
+      add_translation_keys(site.data['reporting']['overall']['statuses'], site)
+
       if site.data['reporting'].has_key?('extra_fields')
         site.data['reporting']['extra_fields'].each do |key, extra_field|
           extra_field.each do |extra_field_value|
-            add_translation_keys(extra_field_value['statuses'])
+            add_translation_keys(extra_field_value['statuses'], site)
           end
         end
       end
-      puts 'foo3'
+
       if site.data['reporting'].has_key?('goals')
         site.data['reporting']['goals'].each do |key, goal|
           goal.each do |goal_value|
-            add_translation_keys(goal_value['statuses'])
+            add_translation_keys(goal_value['statuses'], site)
           end
         end
       end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -11,7 +11,7 @@ module JekyllOpenSdgPlugins
         status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
         if status_in_site_config.nil?
           opensdg_notice('Unexpected reporting status type: ' + status['status'] + '. Expected reporting status types:'
-          puts site.config['reporting_status']['status_types']
+          puts (site.config['reporting_status']['status_types'].map { |status_type| status_type.value } )
         end
         status['translation_key'] = status_in_site_config['label']
       end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -32,7 +32,7 @@ module JekyllOpenSdgPlugins
       end
 
       add_translation_keys(site.data['reporting']['statuses'])
-      add_translation_keys(site.data['reporting']['overall']['statuses']
+      add_translation_keys(site.data['reporting']['overall']['statuses'])
       if site.data['reporting'].has_key?('extra_fields')
         site.data['reporting']['extra_fields'] each do |key, extra_field|
           extra_field.each do |extra_field_value|

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -14,8 +14,14 @@ module JekyllOpenSdgPlugins
         unless site.config.has_key?('reporting_status') &&
                site.config['reporting_status'].has_key?('status_types') &&
                site.config['reporting_status']['status_types'].count > 0
-            legacy_reporting_status_types = site.data['schema']
-            puts legacy_reporting_status_types
+            reporting_status = site.data['schema'].detect {|f| f['name'] == 'reporting_status' }
+            reporting_status_types = reporting_status['field']['options']
+            site.config['reporting_status']['status_types'] = reporting_status_types.map do |status_type|
+              return {
+                'value': status_type['value'],
+                'label': status_type['translation_key'],
+              }
+            end
         end
     end
   end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -10,8 +10,9 @@ module JekyllOpenSdgPlugins
       statuses.each do |status|
         status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['status'] }
         if status_in_site_config.nil?
+          puts site.config['reporting_status']['status_types']
           opensdg_notice('Unexpected reporting status type: ' + status['status'] + '. Expected reporting status types:')
-          puts site.config['reporting_status']['status_types'].map { |status_type| status_type['value'] }
+          puts site.config['reporting_status']['status_types'].map { |s| s['value'] }
         end
         status['translation_key'] = status_in_site_config['label']
       end
@@ -30,7 +31,7 @@ module JekyllOpenSdgPlugins
         site.config['reporting_status']['status_types'] = reporting_status_types.map do |status_type|
           {
             'value': status_type['value'],
-             'label': status_type['translation_key'],
+            'label': status_type['translation_key'],
           }
         end
       end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -36,6 +36,8 @@ module JekyllOpenSdgPlugins
       add_translation_keys(site.data['reporting']['overall']['statuses'], site)
 
       if site.data['reporting'].has_key?('extra_fields')
+        puts 'about to loop'
+        puts site.data['reporting']['extra_fields']
         site.data['reporting']['extra_fields'].each do |key, extra_field|
           extra_field.each do |extra_field_value|
             add_translation_keys(extra_field_value['statuses'], site)

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -34,14 +34,14 @@ module JekyllOpenSdgPlugins
       add_translation_keys(site.data['reporting']['statuses'])
       add_translation_keys(site.data['reporting']['overall']['statuses'])
       if site.data['reporting'].has_key?('extra_fields')
-        site.data['reporting']['extra_fields'] each do |key, extra_field|
+        site.data['reporting']['extra_fields'].each do |key, extra_field|
           extra_field.each do |extra_field_value|
             add_translation_keys(extra_field_value['statuses'])
           end
         end
       end
       if site.data['reporting'].has_key?('goals')
-        site.data['reporting']['goals'] each do |key, goal|
+        site.data['reporting']['goals'].each do |key, goal|
           goal.each do |goal_value|
             add_translation_keys(goal_value['statuses'])
           end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -11,9 +11,10 @@ module JekyllOpenSdgPlugins
     def generate(site)
 
       # Handle legacy treatment of reporting status types.
-      unless site.config.has_key?('reporting_status') &&
+      puts 'foo'
+      unless (site.config.has_key?('reporting_status') &&
              site.config['reporting_status'].has_key?('status_types') &&
-             site.config['reporting_status']['status_types'].count > 0
+             site.config['reporting_status']['status_types'].count > 0)
         reporting_status = site.data['schema'].detect {|f| f['name'] == 'reporting_status' }
         reporting_status_types = reporting_status['field']['options']
         site.config['reporting_status']['status_types'] = reporting_status_types.map do |status_type|
@@ -23,6 +24,7 @@ module JekyllOpenSdgPlugins
           }
         end
       end
+      puts 'foo2'
       # Also fill in the "reporting" data with things needed by older templates.
       def add_translation_keys(statuses)
         statuses.each do |status|
@@ -40,6 +42,7 @@ module JekyllOpenSdgPlugins
           end
         end
       end
+      puts 'foo3'
       if site.data['reporting'].has_key?('goals')
         site.data['reporting']['goals'].each do |key, goal|
           goal.each do |goal_value|

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -9,9 +9,13 @@ module JekyllOpenSdgPlugins
     def add_translation_keys(statuses, site)
       statuses.each do |status|
         puts status
-        status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status['value'] }
+        status_var = 'value'
+        unless status.has_key?(status_var)
+          status_var = 'status'
+        end
+        status_in_site_config = site.config['reporting_status']['status_types'].detect {|s| s['value'] == status[status_var]] }
         if status_in_site_config.nil?
-          opensdg_notice('Unexpected reporting status type: ' + status['value'] + '. Expected reporting status types:')
+          opensdg_notice('Unexpected reporting status type: ' + status[status_var] + '. Expected reporting status types:')
           puts site.config['reporting_status']['status_types'].map { |s| s['value'] }
         end
         status['translation_key'] = status_in_site_config['label']

--- a/lib/jekyll-open-sdg-plugins/schema-site-config.json
+++ b/lib/jekyll-open-sdg-plugins/schema-site-config.json
@@ -1250,6 +1250,36 @@
                             "type": "boolean",
                             "description": "Whether or not to display disaggregation status tabs. If you enable this setting, you should also use 'expected_disaggregations' in your indicator configuration, in order to provide the disaggregation status report with useful metrics.",
                             "format": "checkbox"
+                        },
+                        "status_types": {
+                            "options": {"collapsed": true},
+                            "type": "array",
+                            "title": "Status types",
+                            "description": "Controls the behavior and labels for the different reporting status types.",
+                            "items": {
+                                "type": "object",
+                                "title": "Status type",
+                                "properties": {
+                                    "value": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "title": "Value",
+                                        "description": "The value of the status type, as it is set in the indicator configuration (eg, 'complete')."
+                                    },
+                                    "label": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "title": "Label",
+                                        "description": "The human-readable label for the status type. Can be a translation key (eg, 'status.reported_online')."
+                                    },
+                                    "hide_on_goal_pages": {
+                                        "type": "boolean",
+                                        "title": "Hide on goal pages",
+                                        "description": "Whether to hide this status type on goal pages. Useful for the most commonly-occuring type.",
+                                        "format": "checkbox"
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -155,3 +155,10 @@ indicator_metadata_form:
   repository_link: https://github.com/open-sdg/open-sdg-data-starter/tree/develop/meta
   scopes:
     - national
+
+reporting_status:
+  status_types:
+    - value: complete
+      label: Complete
+    - value: notstarted
+      label: Not started

--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -162,3 +162,5 @@ reporting_status:
       label: Complete
     - value: notstarted
       label: Not started
+    - value: inprogress
+      label: In progress

--- a/tests/_config.yml
+++ b/tests/_config.yml
@@ -164,3 +164,5 @@ reporting_status:
       label: Not started
     - value: inprogress
       label: In progress
+    - value: notapplicable
+      label: Not applicable


### PR DESCRIPTION
This PR adds in some legacy data related to reporting status, for backwards compatibility with older templates. This does two things:
1. Adds "translation_key" in the list of statuses, for older templates that might still use it
2. Ensures the reporting_status.status_types config setting is preset.

# Definitely use "Squash and merge" for this!