### PR TITLE
Backwards compat for sites without the reporting_status site config

### DIFF
--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -31,6 +31,9 @@ module JekyllOpenSdgPlugins
              site.config['reporting_status']['status_types'].count > 0)
         reporting_status = site.data['schema'].detect {|f| f['name'] == 'reporting_status' }
         reporting_status_types = reporting_status['field']['options']
+        unless site.config.has_key?('reporting_status')
+          site.config['reporting_status'] = {}
+        end
         site.config['reporting_status']['status_types'] = reporting_status_types.map do |status_type|
           {
             'value' => status_type['value'],


### PR DESCRIPTION
This avoids an error that would happen on any site that has no `reporting_status` site configuration setting. For sites using the site config form, this wouldn't be a problem, because their config would at least have `reporting_status: {}`. But any site not using the config form that has not yet added `reporting_status` will get an error when running the build. The error is like this: `undefined method `[]=' for nil:NilClass`.

This PR should avoid that error.