### PR TITLE
Config updates for 1.6.0

### DIFF
--- a/lib/jekyll-open-sdg-plugins/schema-site-config.json
+++ b/lib/jekyll-open-sdg-plugins/schema-site-config.json
@@ -183,7 +183,8 @@
                             "Do not automatically create goals",
                             "goal",
                             "goal-by-target",
-                            "goal-by-target-vertical"
+                            "goal-by-target-vertical",
+                            "goal-with-progress"
                         ]
                     },
                     "description": "The layout to use for the goal pages."

--- a/lib/jekyll-open-sdg-plugins/schema-site-config.json
+++ b/lib/jekyll-open-sdg-plugins/schema-site-config.json
@@ -1423,17 +1423,6 @@
                 }
             ]
         },
-        "sharethis_property": {
-            "type": "string",
-            "title": "ShareThis property",
-            "description": "This setting creates a ShareThis widget along the left side of every page. It should be the property id for your ShareThis account.",
-            "links": [
-                {
-                    "rel": "More information on the sharethis setting",
-                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#sharethis_property"
-                }
-            ]
-        },
         "site_config_form": {
             "options": {"collapsed": true},
             "type": "object",


### PR DESCRIPTION
This adds a label for the goal-with-progress option, so that it will appear in the dropdown.

Also this removes the sharethis config setting, which really could have been done in 1.5.0, but might as well happen now.