### PR TITLE
Deprecation warnings and Bootstrap 5 overrides

### DIFF
--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -101,11 +101,11 @@ module JekyllOpenSdgPlugins
       end
       if site.config.has_key?('header') && site.config['header']['include'] != 'header-menu-left-aligned.html'
         there_was_a_deprecation_notice = true
-        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "header.include" setting will no longer be used because there will only be a single option for headers. To see what this will look like, set "bootstrap_5" to "true".'
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "header.include" setting will no longer be used because there will only be a single option for headers. To see what this will look like, set "bootstrap_5" to "true".')
       end
       if site.config.has_key?('non_global_metadata') && site.config['non_global_metadata'] != ''
         there_was_a_deprecation_notice = true
-        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "non_global_metadata" setting will be removed. Please use the "metadata_tabs" setting to control the labels of the metadata tabs.'
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "non_global_metadata" setting will be removed. Please use the "metadata_tabs" setting to control the labels of the metadata tabs.')
       end
       if !site.config.has_key?('series_toggle') || !site.config['series_toggle']
         there_was_a_deprecation_notice = true

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -109,7 +109,7 @@ module JekyllOpenSdgPlugins
       end
       if !site.config.has_key?('series_toggle') || !site.config['series_toggle']
         there_was_a_deprecation_notice = true
-        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "series_toggle" will be automatically set to "true".
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "series_toggle" will be automatically set to "true".')
       end
     end
   end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -59,6 +59,58 @@ module JekyllOpenSdgPlugins
           add_translation_keys(goal['statuses'], site)
         end
       end
+
+      # Print warnings for settings that are deprecated
+      # and will be removed in version 2.0.0.
+      there_was_a_deprecation_notice = false
+      if !site.config.has_key?('accessible_charts') || !site.config['accessible_charts']
+        there_was_a_deprecation_notice = true
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the accessible_charts setting will be automatically set to true.')
+      end
+      if !site.config.has_key?('accessible_tabs') || !site.config['accessible_tabs']
+        there_was_a_deprecation_notice = true
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the accessible_tabs setting will be automatically set to true.')
+      end
+      if !site.config.has_key?('contrast_type') || site.config['contrast_type'] != 'single'
+        there_was_a_deprecation_notice = true
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the contrast_type setting will be automatically set to "single".')
+      end
+      if site.config.has_key?('create_goals') && site.config['create_goals']['layout'] != 'goal-with-progress'
+        there_was_a_deprecation_notice = true
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the create_goals.layout setting will be automatically set to "goal-with-progress".')
+      end
+      if site.config.has_key?('create_pages')
+        site.config['create_pages'].each do |page|
+          if page['layout'] == 'frontpage'
+            opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "frontpage" layout will become the same as the "frontpage-alt" layout.')
+            there_was_a_deprecation_notice = true
+          end
+        end
+      end
+      if !site.config.has_key?('favicons') || site.config['favicons'] != 'favicon.io'
+        there_was_a_deprecation_notice = true
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the favicons setting will be automatically set to "favicon.io".')
+      end
+      if site.config.has_key?('frontpage_heading') && site.config['frontpage_heading'] != ''
+        there_was_a_deprecation_notice = true
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "frontpage_heading" setting will no longer be used.')
+      end
+      if site.config.has_key?('frontpage_instructions') && site.config['frontpage_instructions'] != ''
+        there_was_a_deprecation_notice = true
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "frontpage_instructions" setting will no longer be used.')
+      end
+      if site.config.has_key?('header') && site.config['header']['include'] != 'header-menu-left-aligned.html'
+        there_was_a_deprecation_notice = true
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "header.include" setting will automatically be set to "header-menu-left-aligned.html".'
+      end
+      if site.config.has_key?('non_global_metadata') && site.config['non_global_metadata'] != ''
+        there_was_a_deprecation_notice = true
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "non_global_metadata" setting will be removed. Please use the "metadata_tabs" setting to control the labels of the metadata tabs.'
+      end
+      if !site.config.has_key?('series_toggle') || !site.config['series_toggle']
+        there_was_a_deprecation_notice = true
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "series_toggle" will be automatically set to "true".
+      end
     end
   end
 end

--- a/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
+++ b/lib/jekyll-open-sdg-plugins/backwards_compatibility.rb
@@ -77,12 +77,12 @@ module JekyllOpenSdgPlugins
       end
       if site.config.has_key?('create_goals') && site.config['create_goals']['layout'] != 'goal-with-progress'
         there_was_a_deprecation_notice = true
-        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the create_goals.layout setting will be automatically set to "goal-with-progress".')
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the create_goals.layout setting will be removed, because there will only be a single option for goal layouts. To see a preview, set "bootstrap_5" to "true".')
       end
       if site.config.has_key?('create_pages')
         site.config['create_pages'].each do |page|
           if page['layout'] == 'frontpage'
-            opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "frontpage" layout will become the same as the "frontpage-alt" layout.')
+            opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "frontpage" layout will change. To see a preview, set "bootstrap_5" to "true".')
             there_was_a_deprecation_notice = true
           end
         end
@@ -101,7 +101,7 @@ module JekyllOpenSdgPlugins
       end
       if site.config.has_key?('header') && site.config['header']['include'] != 'header-menu-left-aligned.html'
         there_was_a_deprecation_notice = true
-        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "header.include" setting will automatically be set to "header-menu-left-aligned.html".'
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "header.include" setting will no longer be used because there will only be a single option for headers. To see what this will look like, set "bootstrap_5" to "true".'
       end
       if site.config.has_key?('non_global_metadata') && site.config['non_global_metadata'] != ''
         there_was_a_deprecation_notice = true
@@ -109,7 +109,7 @@ module JekyllOpenSdgPlugins
       end
       if !site.config.has_key?('series_toggle') || !site.config['series_toggle']
         there_was_a_deprecation_notice = true
-        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "series_toggle" will be automatically set to "true".')
+        opensdg_notice('DEPRECATION NOTICE: In Open SDG 2.0.0, the "series_toggle" will be automatically set to "true". In order to keep the "false" behavior, please rename your "Series" column to something else.')
       end
     end
   end

--- a/lib/jekyll-open-sdg-plugins/create_goals.rb
+++ b/lib/jekyll-open-sdg-plugins/create_goals.rb
@@ -78,6 +78,9 @@ module JekyllOpenSdgPlugins
       self.data['goal_number'] = goal.to_s
       self.data['language'] = language
       self.data['layout'] = layout
+      if site.config['bootstrap_5']
+        self.data['layout'] = 'goal-bootstrap5'
+      end
       # Backwards compatibility:
       self.data['sdg_goal'] = self.data['goal_number']
     end

--- a/lib/jekyll-open-sdg-plugins/create_indicators.rb
+++ b/lib/jekyll-open-sdg-plugins/create_indicators.rb
@@ -158,6 +158,9 @@ module JekyllOpenSdgPlugins
       self.data = {}
       self.data['indicator_number'] = inid.gsub('-', '.')
       self.data['layout'] = layout
+      if site.config['bootstrap_5']
+        self.data['layout'] = 'indicator-bootstrap5'
+      end
       self.data['language'] = language
       # Backwards compatibility:
       self.data['indicator'] = self.data['indicator_number']

--- a/lib/jekyll-open-sdg-plugins/create_pages.rb
+++ b/lib/jekyll-open-sdg-plugins/create_pages.rb
@@ -130,6 +130,16 @@ module JekyllOpenSdgPlugins
           self.data[key] = value
         end
       end
+
+      if site.config['bootstrap_5']
+        if page.has_key?('layout') && page['layout'] == 'reportingstatus'
+          self.data['layout'] = 'reportingstatus-bootstrap5'
+        end
+        if page.has_key?('layout') && page['layout'] == 'frontpage'
+          self.data['layout'] = 'frontpage-alt'
+        end
+        self.data['layout'] = 'goal-bootstrap5'
+      end
     end
   end
 end

--- a/lib/jekyll-open-sdg-plugins/create_pages.rb
+++ b/lib/jekyll-open-sdg-plugins/create_pages.rb
@@ -138,7 +138,6 @@ module JekyllOpenSdgPlugins
         if page.has_key?('layout') && page['layout'] == 'frontpage'
           self.data['layout'] = 'frontpage-alt'
         end
-        self.data['layout'] = 'goal-bootstrap5'
       end
     end
   end

--- a/lib/jekyll-open-sdg-plugins/schema-site-config.json
+++ b/lib/jekyll-open-sdg-plugins/schema-site-config.json
@@ -56,6 +56,18 @@
                 }
             ]
         },
+        "bootstrap_5": {
+            "title": "Bootstrap 5",
+            "type": "boolean",
+            "description": "This setting can be set to `true` to enable Bootstrap 5. Importantly, this will automatically be set to 'true' in Open SDG 2.0.0.",
+            "format": "checkbox",
+            "links": [
+                {
+                    "rel": "More information on the bootstrap_5 setting",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#bootstrap_5"
+                }
+            ]
+        },
         "breadcrumbs": {
             "options": {"collapsed": true},
             "type": "object",
@@ -94,6 +106,18 @@
                 {
                     "rel": "More information on the breadcrumbs setting",
                     "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#breadcrumbs"
+                }
+            ]
+        },
+        "chartjs_3": {
+            "title": "Chart.js 3",
+            "type": "boolean",
+            "description": "This setting can be set to `true` to enable Chart.js 3. Importantly, this will automatically be set to 'true' in Open SDG 2.0.0.",
+            "format": "checkbox",
+            "links": [
+                {
+                    "rel": "More information on the chartjs_3 setting",
+                    "href": "https://open-sdg.readthedocs.io/en/latest/configuration/#chartjs_3"
                 }
             ]
         },


### PR DESCRIPTION
This PR is meant to help prepare for version 2.0.0:

* During builds, display some deprecation warnings depending on site config
* Override some layouts if bootstrap_5 is enabled

Here is a plain-English description of the deprecation warnings:

1. If the site config has `accessible_charts` turned off or missing, display this warning:

    DEPRECATION NOTICE: In Open SDG 2.0.0, the accessible_charts setting will be automatically set to true.
2. If the site config has `accessible_tabs` turned off or missing, display this warning:

    DEPRECATION NOTICE: In Open SDG 2.0.0, the accessible_tabs setting will be automatically set to true.
3. If the site config has a `contrast_type` of anything other than `single`, or it's missing, display this warning:

    DEPRECATION NOTICE: In Open SDG 2.0.0, the contrast_type setting will be automatically set to "single".
4. If the site config has a `create_goals.layout` setting of anything other than `goal-with-progress`, display this warning:
    
    DEPRECATION NOTICE: In Open SDG 2.0.0, the create_goals.layout setting will be removed, because there will only be a single option for goal layouts. To see a preview, set "bootstrap_5" to "true".
5. If the frontpage is using the 'frontpage` layout (as opposed to `frontpage-alt`) display this warning:

    DEPRECATION NOTICE: In Open SDG 2.0.0, the "frontpage" layout will change. To see a preview, set "bootstrap_5" to "true".
6. If the site config has `favicons` set to anything other than `favicon.io` or is missing, display this warning:

    DEPRECATION NOTICE: In Open SDG 2.0.0, the favicons setting will be automatically set to "favicon.io".
7. If the site config has anything for `frontpage_heading`, display this warning:

    DEPRECATION NOTICE: In Open SDG 2.0.0, the "frontpage_heading" setting will no longer be used.
8. If the site config has anything for `frontpage_instructions`, display this warning:

    DEPRECATION NOTICE: In Open SDG 2.0.0, the "frontpage_instructions" setting will no longer be used.
9. If the site config `header.include` setting is anything other than `header-menu-left-aligned.html`, display this warning:

    DEPRECATION NOTICE: In Open SDG 2.0.0, the "header.include" setting will no longer be used because there will only be a single option for headers. To see what this will look like, set "bootstrap_5" to "true".
10. If the site config has anything for `non_global_metadata`, display this warning:

    DEPRECATION NOTICE: In Open SDG 2.0.0, the "non_global_metadata" setting will be removed. Please use the "metadata_tabs" setting to control the labels of the metadata tabs.
11. If the site config has `series_toggle` set to `false` or it's missing, display this warning:

    DEPRECATION NOTICE: In Open SDG 2.0.0, the "series_toggle" will be automatically set to "true". In order to keep the "false" behavior, please rename your "Series" column to something else.
```