### PR TITLE
Un-protect indicator_number metadata field

### DIFF
--- a/lib/jekyll-open-sdg-plugins/sdg_variables.rb
+++ b/lib/jekyll-open-sdg-plugins/sdg_variables.rb
@@ -294,7 +294,7 @@ module JekyllOpenSdgPlugins
       # country-specific metadata doesn't use any of these fields.
       protected_keys = ['goals', 'goal', 'targets', 'target', 'indicators',
         'indicator', 'language', 'name', 'number', 'sort', 'global', 'url',
-        'goal_number', 'target_number', 'indicator_number'
+        'goal_number', 'target_number'
       ]
 
       # Figure out from our translations the global indicator numbers.


### PR DESCRIPTION
Countries were using this metadata field, and it doesn't technically need to be protected, so let's un-protect it to preserve behavior.